### PR TITLE
fix(router): prevent back-navigation loops by adding `replace` to Nav…

### DIFF
--- a/src/Router/routes.tsx
+++ b/src/Router/routes.tsx
@@ -5,19 +5,41 @@ import Home from '../components/Home/Home';
 import { PerfilUser } from '../components/Perfil/Perfil';
 
 interface AppRouterProps {
-    isAuthenticated: boolean;
-    setIsAuthenticated: React.Dispatch<React.SetStateAction<boolean>>;
-  }
-
-const AppRouter: React.FC<AppRouterProps> = ({ isAuthenticated , setIsAuthenticated }) => {
-    return (
-        <Routes>
-            <Route path="/" element={isAuthenticated ? <Home /> : <Navigate to="/login" />} />
-            <Route path="/login" element={isAuthenticated ? <Navigate to="/" /> : <Login setIsAuthenticated={setIsAuthenticated} />} />
-            <Route path="*" element={<Navigate to="/login" />} />
-            <Route path='/perfil' element={isAuthenticated ? <PerfilUser /> : <Navigate to="/login" />} />
-        </Routes>
-    );
+  isAuthenticated: boolean;
+  setIsAuthenticated: React.Dispatch<React.SetStateAction<boolean>>;
 }
+
+const AppRouter: React.FC<AppRouterProps> = ({
+  isAuthenticated,
+  setIsAuthenticated,
+}) => {
+  return (
+    <Routes>
+      <Route
+        path="/"
+        element={
+          isAuthenticated ? <Home /> : <Navigate to="/login" replace />
+        }
+      />
+      <Route
+        path="/login"
+        element={
+          isAuthenticated ? (
+            <Navigate to="/" replace />
+          ) : (
+            <Login setIsAuthenticated={setIsAuthenticated} />
+          )
+        }
+      />
+      <Route path="*" element={<Navigate to="/login" replace />} />
+      <Route
+        path="/perfil"
+        element={
+          isAuthenticated ? <PerfilUser /> : <Navigate to="/login" replace />
+        }
+      />
+    </Routes>
+  );
+};
 
 export default AppRouter;


### PR DESCRIPTION
Adicionei a prop replace em todas as instâncias de <Navigate> (raiz, login, perfil e rota curinga). Com isso, o redirecionamento passa a substituir a entrada atual no histórico, impedindo que o usuário volte para a tela de login ou para rotas protegidas ao clicar em “voltar”. 

O fluxo de navegação fica mais intuitivo e evita loops ou telas inconsistentes.